### PR TITLE
feat: require AUTH_USERNAME and AUTH_PASSWORD at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Runs as a single Docker container; the archive directory is mounted as a volume.
 
 | Variable        | Default    | Description                                             |
 | --------------- | ---------- | ------------------------------------------------------- |
-| `AUTH_USERNAME` | `admin`    | Login username                                          |
-| `AUTH_PASSWORD` | `changeme` | Login password — **always override in production**      |
+| `AUTH_USERNAME` | *required* | Login username                                          |
+| `AUTH_PASSWORD` | *required* | Login password                                          |
 | `ARCHIVE_ROOT`  | `/archive` | Absolute path inside the container to the archive root  |
 | `PUID`          | (unset)    | UID of the user that owns the archive files on the host |
 | `PGID`          | (unset)    | GID of the user that owns the archive files on the host |

--- a/src/backend/FL.LigArchivar.Api.Tests/ArchiveApiFactory.cs
+++ b/src/backend/FL.LigArchivar.Api.Tests/ArchiveApiFactory.cs
@@ -35,6 +35,8 @@ public class ArchiveApiFactory : WebApplicationFactory<Program>
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ARCHIVE_ROOT"] = "/archive",
+                ["AUTH_USERNAME"] = "admin",
+                ["AUTH_PASSWORD"] = "changeme",
             });
         });
 

--- a/src/backend/FL.LigArchivar.Api/Controllers/AuthController.cs
+++ b/src/backend/FL.LigArchivar.Api/Controllers/AuthController.cs
@@ -22,8 +22,8 @@ public class AuthController : ControllerBase
     [AllowAnonymous]
     public async Task<IActionResult> Login([FromBody] LoginRequestDto request)
     {
-        var expectedUsername = _configuration["AUTH_USERNAME"] ?? "admin";
-        var expectedPassword = _configuration["AUTH_PASSWORD"] ?? "changeme";
+        var expectedUsername = _configuration["AUTH_USERNAME"]!;
+        var expectedPassword = _configuration["AUTH_PASSWORD"]!;
 
         if (request.Username != expectedUsername || request.Password != expectedPassword)
             return Unauthorized();

--- a/src/backend/FL.LigArchivar.Api/Program.cs
+++ b/src/backend/FL.LigArchivar.Api/Program.cs
@@ -4,6 +4,14 @@ using FL.LigArchivar.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// ── Required configuration ────────────────────────────────────────────────────
+
+if (string.IsNullOrWhiteSpace(builder.Configuration["AUTH_USERNAME"]))
+    throw new InvalidOperationException("AUTH_USERNAME is required and must not be empty.");
+
+if (string.IsNullOrWhiteSpace(builder.Configuration["AUTH_PASSWORD"]))
+    throw new InvalidOperationException("AUTH_PASSWORD is required and must not be empty.");
+
 // ── Services ─────────────────────────────────────────────────────────────────
 
 builder.Services.AddControllers();


### PR DESCRIPTION
## Summary

- `Program.cs` now validates `AUTH_USERNAME` and `AUTH_PASSWORD` at startup and throws `InvalidOperationException` if either is missing or empty — the container refuses to start instead of silently falling back to insecure defaults
- `AuthController.cs` removes the `?? "admin"` / `?? "changeme"` fallbacks since startup validation guarantees the values are present
- `ArchiveApiFactory.cs` explicitly injects test credentials via in-memory configuration so all integration tests continue to pass
- `README.md` marks both variables as *required* instead of showing default values

## Test plan

- [x] All 34 tests pass locally (`dotnet test`)
- [ ] Verify the container fails to start without `AUTH_USERNAME` / `AUTH_PASSWORD` set in `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)