### PR TITLE
chore: bump NuGet packages (combined Dependabot updates)

### DIFF
--- a/src/backend/Directory.Packages.props
+++ b/src/backend/Directory.Packages.props
@@ -4,14 +4,14 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Core -->
-    <PackageVersion Include="System.IO.Abstractions" Version="21.1.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+    <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <!-- Tests -->
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
-    <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="21.1.3" />
+    <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Combines 5 Dependabot NuGet PRs into one. All changes are in `src/backend/Directory.Packages.props`.

| Package | From | To |
|---------|------|----|
| `System.IO.Abstractions` | 21.1.3 | 22.1.1 |
| `System.IO.Abstractions.TestingHelpers` | 21.1.3 | 22.1.1 |
| `Microsoft.Extensions.Logging.Abstractions` | 9.0.4 | 10.0.5 |
| `Microsoft.AspNetCore.Mvc.Testing` | 10.0.0 | 10.0.5 |
| `Microsoft.NET.Test.Sdk` | 17.13.0 | 18.4.0 |

Closes #32, #33, #34, #35, #36

## Test plan

- [x] All 34 tests pass locally (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)