### PR TITLE
fix: suppress expected Data Protection ephemeral-key warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,6 @@ services:
       # on the host so the container process can read and rename them.
       # - PUID=1000
       # - PGID=1000
+      # Set to "json" for structured JSON log output (default: plain text).
+      # - LOG_FORMAT=json
     restart: unless-stopped

--- a/src/backend/FL.LigArchivar.Api/Program.cs
+++ b/src/backend/FL.LigArchivar.Api/Program.cs
@@ -4,6 +4,14 @@ using FL.LigArchivar.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// ── Logging format ────────────────────────────────────────────────────────────
+
+if (string.Equals(builder.Configuration["LOG_FORMAT"], "json", StringComparison.OrdinalIgnoreCase))
+{
+    builder.Logging.ClearProviders();
+    builder.Logging.AddJsonConsole();
+}
+
 // ── Required configuration ────────────────────────────────────────────────────
 
 if (string.IsNullOrWhiteSpace(builder.Configuration["AUTH_USERNAME"]))

--- a/src/backend/FL.LigArchivar.Api/appsettings.json
+++ b/src/backend/FL.LigArchivar.Api/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.DataProtection": "Error"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## Summary

- Adds `"Microsoft.AspNetCore.DataProtection": "Error"` to the `LogLevel` section in `appsettings.json` — the ephemeral-key warnings are expected and not actionable for this app
- Adds `LOG_FORMAT` environment variable support: set to `json` for structured JSON console output, omit for the default plain-text format

## Usage

In `docker-compose.yml` (uncomment to enable JSON logging):
```yaml
# - LOG_FORMAT=json
```

## Test plan

- [ ] Start the app and confirm the three `warn: Microsoft.AspNetCore.DataProtection.*` lines no longer appear
- [ ] Verify login / logout still works normally
- [ ] Start with `LOG_FORMAT=json` and confirm log lines are emitted as JSON objects
- [ ] Start without `LOG_FORMAT` and confirm plain-text log output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)