### PR TITLE
feat: collapse tree by default, add expand/collapse all, move reload button

### DIFF
--- a/src/frontend/src/components/ArchiveTree.module.css
+++ b/src/frontend/src/components/ArchiveTree.module.css
@@ -1,3 +1,32 @@
+.treeControls {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem 0.25rem 0.375rem;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 0.25rem;
+}
+
+.treeBtn {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.treeBtn:hover:not(:disabled) {
+  background: var(--color-hover);
+}
+
+.treeBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .tree,
 .subtree {
   list-style: none;

--- a/src/frontend/src/components/ArchiveTree.tsx
+++ b/src/frontend/src/components/ArchiveTree.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import type { TreeNodeDto } from '../types/archive';
 import styles from './ArchiveTree.module.css';
 
@@ -10,23 +10,50 @@ interface ArchiveTreeProps {
   isReloading?: boolean;
 }
 
+function collectBranchPaths(nodes: TreeNodeDto[]): string[] {
+  const paths: string[] = [];
+  for (const node of nodes) {
+    if (node.children && node.children.length > 0) {
+      paths.push(node.path);
+      paths.push(...collectBranchPaths(node.children));
+    }
+  }
+  return paths;
+}
+
 export function ArchiveTree({ nodes, selectedPath, onSelectEvent, onReload, isReloading }: ArchiveTreeProps) {
-  const [expandSignal, setExpandSignal] = useState(0);
-  const [collapseSignal, setCollapseSignal] = useState(0);
+  const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<string>>(new Set());
+
+  function handleToggle(path: string) {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  function handleExpandAll() {
+    setExpandedPaths(new Set(collectBranchPaths(nodes)));
+  }
+
+  function handleCollapseAll() {
+    setExpandedPaths(new Set());
+  }
 
   return (
     <div>
       <div className={styles.treeControls}>
         <button
           className={styles.treeBtn}
-          onClick={() => setExpandSignal((n) => n + 1)}
+          onClick={handleExpandAll}
           title="Alle aufklappen"
         >
           ▾ Alle
         </button>
         <button
           className={styles.treeBtn}
-          onClick={() => setCollapseSignal((n) => n + 1)}
+          onClick={handleCollapseAll}
           title="Alle zuklappen"
         >
           ▸ Keine
@@ -49,9 +76,9 @@ export function ArchiveTree({ nodes, selectedPath, onSelectEvent, onReload, isRe
             node={node}
             selectedPath={selectedPath}
             onSelectEvent={onSelectEvent}
+            expandedPaths={expandedPaths}
+            onToggle={handleToggle}
             depth={0}
-            expandSignal={expandSignal}
-            collapseSignal={collapseSignal}
           />
         ))}
       </ul>
@@ -63,31 +90,22 @@ interface TreeNodeProps {
   node: TreeNodeDto;
   selectedPath: string | null;
   onSelectEvent: (path: string) => void;
+  expandedPaths: ReadonlySet<string>;
+  onToggle: (path: string) => void;
   depth: number;
-  expandSignal: number;
-  collapseSignal: number;
 }
 
-function TreeNode({ node, selectedPath, onSelectEvent, depth, expandSignal, collapseSignal }: TreeNodeProps) {
-  const [expanded, setExpanded] = useState(false);
-
+function TreeNode({ node, selectedPath, onSelectEvent, expandedPaths, onToggle, depth }: TreeNodeProps) {
+  const expanded = expandedPaths.has(node.path);
   const hasChildren = node.children && node.children.length > 0;
   const isSelected = node.path === selectedPath;
   const isEvent = node.nodeType === 'event';
-
-  useEffect(() => {
-    if (expandSignal > 0 && hasChildren) setExpanded(true);
-  }, [expandSignal]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (collapseSignal > 0) setExpanded(false);
-  }, [collapseSignal]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleClick() {
     if (isEvent) {
       onSelectEvent(node.path);
     } else if (hasChildren) {
-      setExpanded((prev) => !prev);
+      onToggle(node.path);
     }
   }
 
@@ -149,9 +167,9 @@ function TreeNode({ node, selectedPath, onSelectEvent, depth, expandSignal, coll
               node={child}
               selectedPath={selectedPath}
               onSelectEvent={onSelectEvent}
+              expandedPaths={expandedPaths}
+              onToggle={onToggle}
               depth={depth + 1}
-              expandSignal={expandSignal}
-              collapseSignal={collapseSignal}
             />
           ))}
         </ul>

--- a/src/frontend/src/components/ArchiveTree.tsx
+++ b/src/frontend/src/components/ArchiveTree.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { TreeNodeDto } from '../types/archive';
 import styles from './ArchiveTree.module.css';
 
@@ -6,21 +6,56 @@ interface ArchiveTreeProps {
   nodes: TreeNodeDto[];
   selectedPath: string | null;
   onSelectEvent: (path: string) => void;
+  onReload?: () => void;
+  isReloading?: boolean;
 }
 
-export function ArchiveTree({ nodes, selectedPath, onSelectEvent }: ArchiveTreeProps) {
+export function ArchiveTree({ nodes, selectedPath, onSelectEvent, onReload, isReloading }: ArchiveTreeProps) {
+  const [expandSignal, setExpandSignal] = useState(0);
+  const [collapseSignal, setCollapseSignal] = useState(0);
+
   return (
-    <ul className={styles.tree} role="tree">
-      {nodes.map((node) => (
-        <TreeNode
-          key={node.path}
-          node={node}
-          selectedPath={selectedPath}
-          onSelectEvent={onSelectEvent}
-          depth={0}
-        />
-      ))}
-    </ul>
+    <div>
+      <div className={styles.treeControls}>
+        <button
+          className={styles.treeBtn}
+          onClick={() => setExpandSignal((n) => n + 1)}
+          title="Alle aufklappen"
+        >
+          ▾ Alle
+        </button>
+        <button
+          className={styles.treeBtn}
+          onClick={() => setCollapseSignal((n) => n + 1)}
+          title="Alle zuklappen"
+        >
+          ▸ Keine
+        </button>
+        {onReload && (
+          <button
+            className={styles.treeBtn}
+            onClick={onReload}
+            disabled={isReloading}
+            title="Archiv neu laden"
+          >
+            {isReloading ? 'Laden…' : 'Neu laden'}
+          </button>
+        )}
+      </div>
+      <ul className={styles.tree} role="tree">
+        {nodes.map((node) => (
+          <TreeNode
+            key={node.path}
+            node={node}
+            selectedPath={selectedPath}
+            onSelectEvent={onSelectEvent}
+            depth={0}
+            expandSignal={expandSignal}
+            collapseSignal={collapseSignal}
+          />
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -29,16 +64,24 @@ interface TreeNodeProps {
   selectedPath: string | null;
   onSelectEvent: (path: string) => void;
   depth: number;
+  expandSignal: number;
+  collapseSignal: number;
 }
 
-function TreeNode({ node, selectedPath, onSelectEvent, depth }: TreeNodeProps) {
-  // Expand asset/year/club nodes by default; events and invalid/ignored collapsed
-  const isLeafLike = node.nodeType === 'event' || node.nodeType === 'invalid' || node.nodeType === 'ignored';
-  const [expanded, setExpanded] = useState(!isLeafLike && depth <= 1);
+function TreeNode({ node, selectedPath, onSelectEvent, depth, expandSignal, collapseSignal }: TreeNodeProps) {
+  const [expanded, setExpanded] = useState(false);
 
   const hasChildren = node.children && node.children.length > 0;
   const isSelected = node.path === selectedPath;
   const isEvent = node.nodeType === 'event';
+
+  useEffect(() => {
+    if (expandSignal > 0 && hasChildren) setExpanded(true);
+  }, [expandSignal]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (collapseSignal > 0) setExpanded(false);
+  }, [collapseSignal]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleClick() {
     if (isEvent) {
@@ -107,6 +150,8 @@ function TreeNode({ node, selectedPath, onSelectEvent, depth }: TreeNodeProps) {
               selectedPath={selectedPath}
               onSelectEvent={onSelectEvent}
               depth={depth + 1}
+              expandSignal={expandSignal}
+              collapseSignal={collapseSignal}
             />
           ))}
         </ul>

--- a/src/frontend/src/pages/MainView.module.css
+++ b/src/frontend/src/pages/MainView.module.css
@@ -29,26 +29,6 @@
   gap: 0.5rem;
 }
 
-.reloadBtn {
-  padding: 0.25rem 0.75rem;
-  font-size: 0.8125rem;
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  background: none;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.reloadBtn:hover:not(:disabled) {
-  background: var(--color-hover);
-}
-
-.reloadBtn:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
 .logoutBtn {
   padding: 0.25rem 0.75rem;
   font-size: 0.8125rem;

--- a/src/frontend/src/pages/MainView.tsx
+++ b/src/frontend/src/pages/MainView.tsx
@@ -91,14 +91,6 @@ export function MainView({ onLoggedOut }: MainViewProps) {
       <header className={styles.header}>
         <span className={styles.brand}>LigArchivar</span>
         <div className={styles.headerActions}>
-          <button
-            className={styles.reloadBtn}
-            onClick={handleReload}
-            disabled={treeQuery.isFetching || eventQuery.isFetching}
-            title="Archiv neu laden"
-          >
-            {treeQuery.isFetching || eventQuery.isFetching ? 'Laden…' : 'Neu laden'}
-          </button>
           <button className={styles.logoutBtn} onClick={handleLogout}>
             Abmelden
           </button>
@@ -120,6 +112,8 @@ export function MainView({ onLoggedOut }: MainViewProps) {
               nodes={treeQuery.data}
               selectedPath={selectedPath}
               onSelectEvent={handleSelectEvent}
+              onReload={handleReload}
+              isReloading={treeQuery.isFetching || eventQuery.isFetching}
             />
           )}
         </aside>


### PR DESCRIPTION
## Summary

- Tree nodes now **start fully collapsed** when the app loads
- Added **\"▾ Alle\"** (expand all) and **\"▸ Keine\"** (collapse all) buttons above the tree in the sidebar
- **Moved the reload button** from the top header into the sidebar toolbar alongside the expand/collapse buttons
- Individual node toggling still works independently after using expand/collapse all

## Test plan

- [ ] On load, all tree nodes are collapsed
- [ ] Clicking \"▾ Alle\" expands all branch nodes; leaf events/invalid/ignored remain non-expandable
- [ ] Clicking \"▸ Keine\" collapses all nodes
- [ ] After expanding/collapsing all, individual nodes can still be toggled normally
- [ ] Reload button in sidebar toolbar refetches the tree (and current event if one is selected)
- [ ] Reload button shows \"Laden…\" and is disabled while fetching
- [ ] Header no longer contains the reload button

🤖 Generated with [Claude Code](https://claude.com/claude-code)