### PR TITLE
chore: auto-merge dependabot minor, patch, and build updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for minor, patch, and build updates
+        if: >
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.package-ecosystem == 'github_actions' ||
+          steps.meta.outputs.package-ecosystem == 'docker'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml` which enables GitHub auto-merge (squash) on Dependabot PRs for semver-minor/patch updates and for the `github_actions` and `docker` ecosystems.
- Relies on existing branch protection + `pr.yml` checks to gate the actual merge — auto-merge only fires once required checks pass.

## Prerequisites
- [x] "Allow auto-merge" enabled in repo **Settings → General**.
- [ ] Branch protection on `main` requires the `pr.yml` checks to pass.

## Test plan
- [ ] Wait for the next Dependabot PR (or manually trigger one) and confirm the workflow enables auto-merge.
- [ ] Confirm a major version bump is **not** auto-merged.
- [ ] Confirm PR only merges after `pr.yml` jobs succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)