### PR TITLE
chore: group dependabot updates for automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,98 @@ updates:
     directory: "/src/frontend"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "deps(frontend)"
+    groups:
+      frontend-runtime:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      frontend-build-tooling:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "nuget"
     directory: "/src/backend"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "deps(backend)"
+    groups:
+      dotnet-runtime:
+        patterns:
+          - "Microsoft.Extensions.*"
+          - "System.IO.Abstractions"
+        update-types:
+          - "minor"
+          - "patch"
+      dotnet-tests:
+        patterns:
+          - "*.Testing"
+          - "*.TestingHelpers"
+          - "*Test*"
+          - "FluentAssertions"
+          - "Microsoft.NET.Test.Sdk"
+          - "xunit*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "deps(actions)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:45"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,9 +1,14 @@
 name: Dependabot auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions:
   contents: write
@@ -11,19 +16,28 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for minor, patch, and build updates
-        if: >
-          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.package-ecosystem == 'github_actions' ||
-          steps.meta.outputs.package-ecosystem == 'docker'
+      - name: Check update safety
+        id: safety
+        run: |
+          if jq -e 'all(.[]; .["update-type"] == "version-update:semver-minor" or .["update-type"] == "version-update:semver-patch")' <<< "$UPDATED_DEPENDENCIES"; then
+            echo "safe=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "safe=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          UPDATED_DEPENDENCIES: ${{ steps.meta.outputs.updated-dependencies-json }}
+
+      - name: Enable auto-merge for safe dependency updates
+        if: steps.safety.outputs.safe == 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- group Dependabot updates by frontend, backend, CI, and Docker concerns
- auto-enable squash auto-merge only when all Dependabot updates are semver minor or patch
- use pull_request_target without checkout or long-lived credentials

## GitHub setup
1. Enable Settings > General > Pull Requests > Allow auto-merge.
2. Set Settings > Actions > General > Workflow permissions to Read and write permissions.
3. Keep Allow GitHub Actions to create and approve pull requests disabled if unavailable; this workflow does not create or approve PRs.
4. Enable Dependabot alerts, security updates, and version updates under Code security and analysis.
5. Require the existing PR validation checks on main, but do not require manual review for Dependabot PRs.

## Notes
- Uses only the repository-scoped GITHUB_TOKEN.
- No PATs, private keys, or long-lived secrets are needed.