### PR TITLE
fix: read Dependabot update type metadata

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check update safety
         id: safety
         run: |
-          if jq -e 'all(.[]; .["update-type"] == "version-update:semver-minor" or .["update-type"] == "version-update:semver-patch")' <<< "$UPDATED_DEPENDENCIES"; then
+          if jq -e 'all(.[]; .updateType == "version-update:semver-minor" or .updateType == "version-update:semver-patch")' <<< "$UPDATED_DEPENDENCIES"; then
             echo "safe=true" >> "$GITHUB_OUTPUT"
           else
             echo "safe=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- fix Dependabot auto-merge safety check for fetch-metadata v3 JSON output
- use the camelCase updateType key emitted in updated-dependencies-json

## Root cause
The workflow checked .["update-type"], but dependabot/fetch-metadata@v3 emits updateType in updated-dependencies-json. The safety step therefore evaluated to false and skipped the auto-merge step.

## Verification
- inspected the failed auto-merge workflow log for PR #113
- git diff --check passes